### PR TITLE
fix: aislar caché de Apollo por idioma para evitar contenido mezclado

### DIFF
--- a/gatsby-browser.js
+++ b/gatsby-browser.js
@@ -28,9 +28,59 @@ const httpLink = new HttpLink({
   fetch,
 })
 
+// Hygraph returns the same `id` for every locale of a translated entry, so the
+// default Apollo cache key (__typename:id) collides across locales and lets a
+// stale-language response overwrite the current one. Include the query's
+// locale in the key so each language gets its own cache entry.
+const localizedTypenames = [
+  "AboutUsAndOurTeam",
+  "AirportAndOfficePage",
+  "CampingPage",
+  "Car",
+  "CarQuoteForm",
+  "CarsAndQuote",
+  "ContactAndLocation",
+  "Faq",
+  "FrequentAnswersAndQuestion",
+  "HeaderAndFooterElement",
+  "Imprint",
+  "Index",
+  "Insurance",
+  "Menu",
+  "Post",
+  "RentalInfo",
+  "Review",
+  "RoadSafety",
+  "Seos",
+  "Testimonial",
+  "TravelPlanner",
+]
+
+const localizedKeyFields = (obj, { variables }) => {
+  // Some queries (e.g. the language selector) fetch these types without
+  // selecting `id`. Leave those un-normalized instead of colliding on
+  // "TypeName:undefined:..." with every other id-less query for the type.
+  if (obj.id == null) return false
+  return `${obj.__typename}:${obj.id}:${JSON.stringify(variables?.locale ?? "")}`
+}
+
+const typePolicies = Object.fromEntries(
+  localizedTypenames.map(typename => [
+    typename,
+    { keyFields: localizedKeyFields },
+  ])
+)
+
 const apolloClient = new ApolloClient({
   link: httpLink,
-  cache: new InMemoryCache(),
+  cache: new InMemoryCache({ typePolicies }),
+  // Revisiting a locale (e.g. switching languages back and forth) reuses the
+  // same query variables Apollo already has a root-query cache entry for.
+  // cache-first would then serve that stale response instead of refetching,
+  // so always revalidate against the network on every render of these queries.
+  defaultOptions: {
+    watchQuery: { fetchPolicy: "cache-and-network" },
+  },
 })
 
 const wrapPageElement = ({ element, props }) => (


### PR DESCRIPTION
## Resumen
Hygraph devuelve el mismo `id` para cada localización de una entrada, así que la normalización por defecto de Apollo (`__typename:id`) colisionaba entre idiomas: al cambiar de idioma con el selector, el menú y otros textos quedaban pegados en el idioma anterior o mezclaban slug/label de dos idiomas distintos, generando enlaces rotos (404 en page-data.json).

## Cambio
- `typePolicies` con `keyFields` que incluye el locale de la query en la clave de caché.
- `fetchPolicy: cache-and-network` para revalidar contra el servidor incluso al revisitar un idioma ya cacheado en la sesión.

## Test plan
- [x] Verificado en local: ES → FR → ES / DE, menú y textos consistentes, sin mezcla de idiomas ni 404 de page-data.json
- [x] Sin errores nuevos en consola